### PR TITLE
Added comment of gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,8 +133,8 @@ dmypy.json
 
 .DS_Store
 
-# url.csv
+# 下記は HTML を取得する URL を記述するための file
 /url.csv
 
-# page_info.csv
+# 下記は取得した HTML を書き込むための CSV ファイル
 /csv/page_info.csv


### PR DESCRIPTION
.gitignoreに書かれている「/url.csv」「/csv/page_info.csv」のファイルの存在意義を追記しました。